### PR TITLE
Use a slightly less new aesophia version for compat

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 {profiles, [
     {local, []},
     {test, [
-        {deps, [{aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"fe5f554"}}},
+        {deps, [{aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"98a4049"}}},
                 {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {ref, "5f03a89"}}}]},
         {erl_opts, [{d, 'TEST'}]}
     ]}


### PR DESCRIPTION
The very latest version changes the API so tests fail in the main ae repo

Revert to one rev older

This PR was sponsored by the ACF